### PR TITLE
Add implementation of encoder client with tests cases.

### DIFF
--- a/__tests__/encoder-client.spec.js
+++ b/__tests__/encoder-client.spec.js
@@ -51,6 +51,11 @@ describe('Encoder client', () => {
     expect(encoder.url).toEqual('https://encoder.test/twirp/decode.iot.encoder.Encoder');
   });
 
+  test('should use default base url if none supplied', () => {
+    const defaultEncoder = new EncoderClient();
+    expect(defaultEncoder.url).toEqual('https://encoder.decodeproject.eu/twirp/decode.iot.encoder.Encoder');
+  });
+
   test('should create stream', async () => {
     // define our mocked response
     mockAxios.post.mockImplementationOnce(() => Promise.resolve({

--- a/__tests__/encoder-client.spec.js
+++ b/__tests__/encoder-client.spec.js
@@ -1,0 +1,131 @@
+/*
+ * DECODE App – A mobile app to control your personal data
+ *
+ * Copyright (C) 2019 – DRIBIA Data Research S.L.
+ *
+ * DECODE App is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * DECODE App is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * email: info@dribia.com
+ */
+
+import mockAxios from 'axios';
+import EncoderClient from '../src/api/encoder-client';
+import EncoderError from '../src/api/errors/encoder-error';
+
+describe('Encoder client', () => {
+  afterEach(() => {
+    mockAxios.post.mockClear();
+  });
+
+  const encoder = new EncoderClient('https://encoder.test');
+
+  const streamConfiguration = {
+    device_token: 'abc123',
+    community_id: 'a8463397-2411-4f4a-8294-eef41dc41a5e',
+    recipient_public_key: 'f99538cf2b2d5472c0da9316b1b51b55',
+    location: {
+      longitude: 2.512,
+      latitude: 54.125,
+    },
+    exposure: 'INDOOR',
+    operations: [],
+  };
+
+  const stream = {
+    stream_uid: 'd5eae59b-050f-4f64-bf8c-4c9b7e39ff9a',
+    token: 'isM4wxuUH3JDrUOg7WvDBdHx4mQiMyW4A3h0Amfzg2I=',
+  };
+
+  test('should set full url when constructed', () => {
+    expect(encoder.url).toEqual('https://encoder.test/twirp/decode.iot.encoder.Encoder');
+  });
+
+  test('should create stream', async () => {
+    // define our mocked response
+    mockAxios.post.mockImplementationOnce(() => Promise.resolve({
+      data: stream,
+    }));
+
+
+    const response = await encoder.createStream(streamConfiguration);
+    expect(response).toEqual(stream);
+
+    expect(mockAxios.post).toHaveBeenCalledWith(
+      'https://encoder.test/twirp/decode.iot.encoder.Encoder/CreateStream',
+      streamConfiguration,
+      {
+        headers: { 'Content-Type': 'application/json' },
+      },
+    );
+    expect(mockAxios.post).toHaveBeenCalledTimes(1);
+  });
+
+  test('should throw an error on failure', async () => {
+    mockAxios.post.mockRejectedValueOnce({
+      response: {
+        data: {
+          msg: 'An error occurred',
+          meta: {
+            twirp_invalid_route: 'POST /foo',
+          },
+        },
+      },
+    });
+
+    try {
+      await encoder.createStream(streamConfiguration);
+    } catch (e) {
+      expect(e).toBeInstanceOf(EncoderError);
+      expect(e.message).toBe('Error creating stream: An error occurred');
+    }
+  });
+
+  test('should delete stream', async () => {
+    // define our mocked response
+    mockAxios.post.mockImplementationOnce(() => Promise.resolve({
+      data: {},
+    }));
+
+    await encoder.deleteStream(stream);
+
+    expect(mockAxios.post).toHaveBeenCalledWith(
+      'https://encoder.test/twirp/decode.iot.encoder.Encoder/DeleteStream',
+      stream,
+      {
+        headers: { 'Content-Type': 'application/json' },
+      },
+    );
+    expect(mockAxios.post).toHaveBeenCalledTimes(1);
+  });
+
+  test('should throw an error on failure', async () => {
+    mockAxios.post.mockRejectedValueOnce({
+      response: {
+        data: {
+          msg: 'An error occurred',
+          meta: {
+            twirp_invalid_route: 'POST /foo',
+          },
+        },
+      },
+    });
+
+    try {
+      await encoder.deleteStream(stream);
+    } catch (e) {
+      expect(e).toBeInstanceOf(EncoderError);
+      expect(e.message).toBe('Error deleting stream: An error occurred');
+    }
+  });
+});

--- a/src/api/encoder-client.js
+++ b/src/api/encoder-client.js
@@ -26,39 +26,6 @@ import EncoderError from './errors/encoder-error';
 const prefix = '/twirp/decode.iot.encoder.Encoder';
 
 /**
- * @typedef {Object} StreamConfiguration - Object containing the complete
- *     definition of a stream
- * @property {string} device_token - Identifier of a device (supplied when
- *     onboarding)
- * @property {string} community_id - Identifier of the the chosen community
- * @property {string} recipient_public_key - Public key part of the
- *     communities' encryption keypair
- * @property {Object} location - The geographical location of the device
- * @property {number} location.longitude - The decimal longitude of the
- *     location
- * @property {number} location.latitude - The decimal latitude of the location
- * @property {string} exposure - The exposure of the device (one of INDOOR or
- *     OUTDOOR)
- * @property {Object[]} operations - List of operations to apply to the device
- * @property {number} operations[].sensor_id - Numeric identifier of a sensor
- * @property {string} operations[].action - Action to apply to the sensor (one
- *     of SHARE, BIN, MOVING_AVG)
- * @property {number[]} operations[].bins - Array of numbers defining a set of
- *     bins into which values should be classified. Required for BIN, an error if
- *     present for other actions
- * @property {number} operations[].interval - Interval in seconds over which
- *     moving average should be calculated. Required for MOVING_AVG, an error if
- *     present for other actions
- */
-
-/**
- * @typedef {Object} Stream - Object containing the identifier and secret
- *     token for a stream
- * @property {string} stream_uid - Identifier of a stream
- * @property {string} token - Secret token required to delete the stream
- */
-
-/**
  * Client for the IoT Stream Encoder. Exposes methods for creating or deleting
  * encrypted streams on the stream encoder service.
  */

--- a/src/api/encoder-client.js
+++ b/src/api/encoder-client.js
@@ -1,0 +1,115 @@
+/*
+ * DECODE App – A mobile app to control your personal data
+ *
+ * Copyright (C) 2019 – DRIBIA Data Research S.L.
+ *
+ * DECODE App is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * DECODE App is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * email: info@dribia.com
+ */
+
+import axios from 'axios';
+import { debugLog } from 'lib/utils';
+import EncoderError from './errors/encoder-error';
+
+const prefix = '/twirp/decode.iot.encoder.Encoder';
+
+/**
+ * @typedef {Object} StreamConfiguration - Object containing the complete
+ *     definition of a stream
+ * @property {string} device_token - Identifier of a device (supplied when
+ *     onboarding)
+ * @property {string} community_id - Identifier of the the chosen community
+ * @property {string} recipient_public_key - Public key part of the
+ *     communities' encryption keypair
+ * @property {Object} location - The geographical location of the device
+ * @property {number} location.longitude - The decimal longitude of the
+ *     location
+ * @property {number} location.latitude - The decimal latitude of the location
+ * @property {string} exposure - The exposure of the device (one of INDOOR or
+ *     OUTDOOR)
+ * @property {Object[]} operations - List of operations to apply to the device
+ * @property {number} operations[].sensor_id - Numeric identifier of a sensor
+ * @property {string} operations[].action - Action to apply to the sensor (one
+ *     of SHARE, BIN, MOVING_AVG)
+ * @property {number[]} operations[].bins - Array of numbers defining a set of
+ *     bins into which values should be classified. Required for BIN, an error if
+ *     present for other actions
+ * @property {number} operations[].interval - Interval in seconds over which
+ *     moving average should be calculated. Required for MOVING_AVG, an error if
+ *     present for other actions
+ */
+
+/**
+ * @typedef {Object} Stream - Object containing the identifier and secret
+ *     token for a stream
+ * @property {string} stream_uid - Identifier of a stream
+ * @property {string} token - Secret token required to delete the stream
+ */
+
+/**
+ * Client for the IoT Stream Encoder. Exposes methods for creating or deleting
+ * encrypted streams on the stream encoder service.
+ */
+class EncoderClient {
+  constructor(url = 'https://encoder.decodeproject.eu') {
+    this.url = `${url}${prefix}`;
+  }
+
+  /**
+   * Create an encoded stream for a device which will start that device
+   * collecting data for the chosen community.
+   *
+   * @param {StreamConfiguration} streamConfiguration - Configuration of the
+   *     new encrypted stream to create
+   * @return {Stream}
+   */
+  async createStream(streamConfiguration) {
+    try {
+      const url = `${this.url}/CreateStream`;
+      debugLog('Going to call: ', url);
+
+      const { data: stream } = await axios.post(url, streamConfiguration, { headers: { 'Content-Type': 'application/json' } });
+      debugLog('Response: ', stream);
+      return stream;
+    } catch (err) {
+      debugLog('Error: ', err);
+      const { response: { data: { msg, meta } } } = err;
+      debugLog('Error details: ', JSON.stringify(meta));
+      throw new EncoderError(`Error creating stream: ${msg}`);
+    }
+  }
+
+  /**
+   * Delete an encoded stream, so stopping any new data being encrypted and
+   * stored for that device configuration.
+   *
+   * @param {Stream} stream - The stream to delete
+   */
+  async deleteStream(stream) {
+    try {
+      const url = `${this.url}/DeleteStream`;
+      debugLog('Going to call: ', url);
+
+      await axios.post(url, stream, { headers: { 'Content-Type': 'application/json' } });
+    } catch (err) {
+      debugLog('Error: ', err);
+      const { response: { data: { msg, meta } } } = err;
+      debugLog('Error details: ', JSON.stringify(meta));
+      throw new EncoderError(`Error deleting stream: ${msg}`);
+    }
+  }
+}
+
+export default EncoderClient;

--- a/src/api/errors/encoder-error.js
+++ b/src/api/errors/encoder-error.js
@@ -1,0 +1,28 @@
+/*
+ * DECODE App – A mobile app to control your personal data
+ *
+ * Copyright (C) 2019 – DRIBIA Data Research S.L.
+ *
+ * DECODE App is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * DECODE App is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * email: info@dribia.com
+ */
+
+class EncoderError {
+  constructor(message) {
+    this.message = message || 'There was an error calling the IoT encoder service';
+  }
+}
+
+export default EncoderError;


### PR DESCRIPTION
The encoder client exposes two methods which allow the caller to:

* create an encoded stream (i.e. join a community) or
* delete a stream (i.e. leave a community).

This PR is the second part of https://github.com/DECODEproject/decodev2/pull/3, and just extends the functionality in that PR to add this second client for the encoder service.